### PR TITLE
Release v2023.04.0-alpha.1

### DIFF
--- a/.github/workflows/create-tag-for-repo.yml
+++ b/.github/workflows/create-tag-for-repo.yml
@@ -46,6 +46,16 @@ jobs:
                 return ''
               }
             }
+
+            github.rest.git.createCommit({
+              owner: '${{ inputs.org }}',
+              repo: '${{ inputs.repo }}',
+              tree: releaseBranch,
+              message: 'Release ${{inputs.tag_version}} Commit',
+              author.name: 'Infratographer Release Robot',
+              author.email: 'github-robot@infratographer.com',
+            })
+
             if (await getRefSHA(tagRef) != '') {
               console.log("Release tag already exists, skipping creation")
               return
@@ -55,6 +65,7 @@ jobs:
               throw new Error('Failed to find SHA for release branch')
               return
             }
+
             github.rest.git.createRef({
               owner: '${{ inputs.org }}',
               repo: '${{ inputs.repo }}',

--- a/releases/release-2023-04/tag-v2023.04.0-alpha.1.yml
+++ b/releases/release-2023-04/tag-v2023.04.0-alpha.1.yml
@@ -1,0 +1,5 @@
+---
+version: v2023.04.0-alpha.1
+title: v2023.04.0 - Alpha Release 1
+announcement: |
+  Testing creating a release commit for the commit.


### PR DESCRIPTION
Cuts the `v2023.04.0-alpha.1` release. Also adds a release commit to the release branch before making the tag.