### PR TITLE
correct quote issue due to template

### DIFF
--- a/goreleaser/base.yml
+++ b/goreleaser/base.yml
@@ -92,7 +92,7 @@ release:
   mode: prepend
   prerelease: auto
   draft: false
-  name_template: "Release {{ or (and (or .IsNightly .IsSnapshot) .Version) (printf "v%s" .Version) }}"
+  name_template: 'Release {{ or (and (or .IsNightly .IsSnapshot) .Version) (printf "v%s" .Version) }}'
   header: |
     # What's Changed
   extra_files:


### PR DESCRIPTION
An issue was introduced when attempting to correct the version tagging. Double quotes were used for a yaml string which contained a go template which also contained quotes.

Switched to use single quotes for yaml, resolving the yaml parsing issue.