### PR TITLE
this updates the goreleaser config to be compliant with version 2

### DIFF
--- a/goreleaser/base.yml
+++ b/goreleaser/base.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
-
+version: 2
 
 before:
   hooks:
@@ -30,7 +30,7 @@ snapshot:
   name_template: "{{ .Tag }}-next"
 
 changelog:
-  skip: false
+  disable: false
   sort: asc
   filters:
     exclude:


### PR DESCRIPTION
goreleaser v2 has been released and there is a slight difference in config.

According to the latest v1 run for [iam-runtime-infratographer](https://github.com/infratographer/iam-runtime-infratographer/actions/runs/9551558300/job/26326143944#step:7:55) the only item we're using which is deprecated is `changelog.skip` has changed to `changelog.disable`

See [goreleaser deprecations](https://goreleaser.com/deprecations/#changelogskip)

This has been updated and the version has been defined as it recommends.

This change will require dependent services which import this config to update to goreleaser v2.