### PR TITLE
Update deprecated `name_template` goreleaser keys

### DIFF
--- a/goreleaser/base.yml
+++ b/goreleaser/base.yml
@@ -27,7 +27,7 @@ checksum:
   name_template: 'checksums.txt'
 
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 
 changelog:
   disable: false
@@ -99,7 +99,7 @@ release:
     - glob: ./schema.graphql
 
 nightly:
-  name_template: main-latest
+  version_template: main-latest
   tag_name: main-latest
   publish_release: false
   keep_single_release: true


### PR DESCRIPTION
We're currently using go-releaser v2.4.8-pro and the latest iam-runtime-infratographer builds have had the following log messages:

```
  • setting defaults
    • DEPRECATED:  snapshot.name_template  should not be used anymore, check https://goreleaser.com/deprecations#snapshotnametemplate for more info
    • DEPRECATED:  nightly.name_template  should not be used anymore, check https://goreleaser.com/deprecations#nightlynametemplate for more info
```

Both of these keys were renamed to `version_template` in v2, this PR just updates them so we are using the latest configuration keys.