### PR TITLE
drop i386 arch

### DIFF
--- a/goreleaser/base.yml
+++ b/goreleaser/base.yml
@@ -12,6 +12,9 @@ builds:
     goos:
       - linux
       - darwin
+    goarch:
+      - amd64
+      - arm64
     ldflags:
       - -s -w
       - -X go.infratographer.com/x/versionx.appName={{.ProjectName}}


### PR DESCRIPTION
This drops the i386 arch which is not supported by entgo. Additionally, this binary is not used in the images produced.