### PR TITLE
fix: correct deprecated format

### DIFF
--- a/goreleaser/base.yml
+++ b/goreleaser/base.yml
@@ -24,7 +24,8 @@ builds:
       - -X go.infratographer.com/x/versionx.builtBy=infratographer-release-bot
 
 archives:
-  - format: binary
+  - formats:
+      - binary
 
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
Corrects the deprecated archive format.

https://goreleaser.com/deprecations/#archivesformat